### PR TITLE
Use pure yarn install

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ -f "/home/node/src/yarn.lock" ];
   then
-    yarn install
+    yarn install --pure-lockfile
     # Check if the installed tree is correct. Install all dependencies if not
     yarn check --verify-tree || NODE_ENV=development yarn install
     yarn cache clean


### PR DESCRIPTION
Not 100% sure about this change, would like some feedback.

Background:
The way yarn's lockfile works is that if there is a change to a dependency in package.json, the lockfile is invalidated on the next `yarn install`, and regenerated to match. This is a good behavior when working locally. But it also means that when you build your artefact on CI, you might get a different set of dependencies than if you later run yarn on the same commit, which in a way defeats the purpose of the lockfile (even though the vast majority of the deps will be the same).

What we can do:
This change will make it so that the install fails if it would modify the lockfile. This will ensure that there will never be a deployed artefact which you cannot 100% reproduce later (barring dependencies actually being deleted from the registry, but that can't be a concern (especially since we go via Artifactory)).

This was recently added to Travis CI, but later reverted because stuff went boom (concerning e.g. Greenkeeper PRs), travis-ci/travis-ci#7395. I still think we should do it, since this image is only used for actual applications being deployed to productions. It is important that we are able to recreate the build at a later time, and not enforcing a pure lockfile undermines that.