### PR TITLE
Read secret file contents with cat (which works) instead of <

### DIFF
--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -18,7 +18,7 @@ export_secrets_from_dir() {
 
     log "Exporting secret '$filename_without_path' as '$secret_name'"
 
-    local secret=$(<$filename);
+    local secret=$(cat $filename);
 
     export "$secret_name=$secret"
   done


### PR DESCRIPTION
Secrets ended up being empty strings because `<` doesn't work for reading files in busybox/sh. It works in bash in our Java image where I lifted the code from, which is why I didn't consider it might fail.

I've actually tested it this time… Sorry 😞 