### PR TITLE
Read ARTIFACTORY_* build args before running Yarn/NPM

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,5 +1,9 @@
 FROM containers.schibsted.io/finntech/node:0.0.0
 
+ONBUILD ARG ARTIFACTORY_USER
+ONBUILD ARG ARTIFACTORY_NPM_SECRET
+ONBUILD ARG ARTIFACTORY_CONTEXT
+
 # Allow installation as non-root user
 ONBUILD RUN npm config set unsafe-perm true
 


### PR DESCRIPTION
This allows for an `.npmrc` with variables:
```
_auth="${ARTIFACTORY_NPM_SECRET}"
always-auth=true
email="${ARTIFACTORY_USER}"
registry="${ARTIFACTORY_CONTEXT}/api/npm/npm-virtual"
```
Use with e.g.
```
docker build --build-arg ARTIFACTORY_USER=me@example.com ...
```