### PR TITLE
Fail build if npm/yarn wants to update their lock files

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -3,6 +3,7 @@ FROM containers.schibsted.io/finntech/node:0.0.0
 ONBUILD ARG ARTIFACTORY_USER
 ONBUILD ARG ARTIFACTORY_NPM_SECRET
 ONBUILD ARG ARTIFACTORY_CONTEXT
+ONBUILD ARG FAIL_ON_DIRTY_LOCKFILE
 
 # Allow installation as non-root user
 ONBUILD RUN npm config set unsafe-perm true

--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ If you need to replace the image again, simply increment the trailing number:
 
 🎉 You're done (again)! 🎉
 
+#### Fail build if npm/yarn lockfile isn't up to date
+
+Normal operation is to run `yarn install` or `npm install`.  If you'd rather fail the build if yarn.lock /
+package-lock.json / npm-shrinkwrap.json isn't updated, set the `FAIL_ON_DIRTY_LOCKFILE` variable to something.
+Now `yarn install --frozen-lockfile` or `npm ci` will be run instead.
+
+```
+docker build --build-arg FAIL_ON_DIRTY_LOCKFILE=yes ...
+```
+
 #### Oh no, it failed
 
 There might be multiple issues when releasing. Here are some possible issues:
@@ -286,7 +296,6 @@ manifest for node:node:9900.15.2-alpine not found
 
 The official node.js Docker image of this version are [not yet in Docker Hub](https://hub.docker.com/_/node/).
 There is nothing you can do beside wait for the official image to be published.
-
 
 ##### Misc
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -2,13 +2,15 @@
 
 set -e
 
-if [ -f "/home/node/src/yarn.lock" ];
-  then
-    yarn install --pure-lockfile
-    # Check if the installed tree is correct. Install all dependencies if not
-    yarn check --verify-tree || NODE_ENV=development yarn install
-    yarn cache clean
-  else
-    npm install
-    npm cache clean --force
+if [ -f "/home/node/src/yarn.lock" ]; then
+  yarn install --frozen-lockfile
+  # Check if the installed tree is correct. Install all dependencies if not
+  yarn check --verify-tree || NODE_ENV=development yarn install
+  yarn cache clean
+elif [ -f "/home/node/src/package-lock.json" ] || [ -f "/home/node/src/npm-shrinkwrap.json" ]; then
+  npm ci
+  npm cache clean --force
+else
+  npm install
+  npm cache clean --force
 fi

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -2,13 +2,21 @@
 
 set -e
 
+if [ -n "${FAIL_ON_DIRTY_LOCKFILE}" ]; then
+  YARN_OPTS="--frozen-lockfile"
+  NPM_CMD="ci"
+else
+  YARN_OPTS=""
+  NPM_CMD="install"
+fi
+
 if [ -f "/home/node/src/yarn.lock" ]; then
-  yarn install --frozen-lockfile
+  yarn install $YARN_OPTS
   # Check if the installed tree is correct. Install all dependencies if not
   yarn check --verify-tree || NODE_ENV=development yarn install
   yarn cache clean
 elif [ -f "/home/node/src/package-lock.json" ] || [ -f "/home/node/src/npm-shrinkwrap.json" ]; then
-  npm ci
+  npm $NPM_CMD
   npm cache clean --force
 else
   npm install


### PR DESCRIPTION
Use `npm ci` and `yarn install --frozen-lockfile` to fail build
if yarn.lock / package-lock.json / npm-shrinkwrap.json isn't updated
before pushing.

This makes sure that the dependencies in the built image aren't
different from the ones used locally.