### PR TITLE
Make sure node user exists before using it

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -24,5 +24,6 @@ ONBUILD RUN apk upgrade -U && \
 
 ONBUILD COPY . ./
 
+ONBUILD RUN adduser -D node 
 ONBUILD RUN chown -R node:node .
 ONBUILD USER node


### PR DESCRIPTION
Sysdig Secure has been reporting a lot of the pods using this base image as "running as root", even though the user running the application in the pod is `node`.  Our Java base image does not have the same issue as the node image, and in that image we call the `adduser` command before using it.