### PR TITLE
Add support for pnpm

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,6 +14,7 @@ WORKDIR /home/node/src
 
 RUN apk upgrade -U && \
     apk add --no-cache dumb-init ca-certificates wget bash && \
+    npm i -g pnpm && \
     update-ca-certificates
 
 COPY scripts /home/node/scripts/

--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -10,7 +10,7 @@ ONBUILD ARG YARN_VERSION
 ONBUILD RUN npm config set unsafe-perm true
 
 # All but package.json is optional
-ONBUILD COPY package.json yarn.lock* .yarnrc* .npmrc* npm-shrinkwrap.json* package-lock.json* ./
+ONBUILD COPY package.json yarn.lock* .yarnrc* .npmrc* npm-shrinkwrap.json* package-lock.json* pnpm-lock.yaml* ./
 
 # Install dependencies for native builds
 # This is in one giant command to keep the image size small
@@ -19,7 +19,7 @@ ONBUILD RUN apk upgrade -U && \
     apk add --no-cache --virtual build-dependencies make gcc g++ python git || \
     apk add --no-cache --virtual build-dependencies make gcc g++ python3 git && \
     install-dependencies.sh && \
-    rm /usr/local/bin/yarn && npm uninstall --loglevel warn --global npm && \
+    rm /usr/local/bin/yarn && npm uninstall --loglevel warn --global pnpm && npm uninstall --loglevel warn --global npm && \
     apk del build-dependencies
 
 ONBUILD COPY . ./

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -24,6 +24,8 @@ if [[ -f "/home/node/src/yarn.lock" || -f "/home/node/src/.yarnrc.yml" || -f "/h
   # Check if the installed tree is correct. Install all dependencies if not
   yarn check --verify-tree || NODE_ENV=development yarn install
   yarn cache clean
+elif [[ -f "/home/node/src/pnpm-lock.yaml" ]]; then
+  pnpm i --prefer-frozen-lockfile --prod
 elif [[ -f "/home/node/src/package-lock.json" || -f "/home/node/src/npm-shrinkwrap.json" ]]; then
   npm $NPM_CMD
   npm cache clean --force


### PR DESCRIPTION
Rationale:

- Yarn v1 is deprecated
- Yarn v2 and v3 have significantly more migration friction
- pnpm has very similar behavior to Yarn v1, and has features for monorepos that Yarn missed