### PR TITLE
Multi arch builds

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,4 +1,5 @@
-FROM containers.schibsted.io/finntech/node:NODE_VERSION_TEMPLATE
+# syntax = edrevo/dockerfile-plus
+INCLUDE+ ../Dockerfile.base
 
 ONBUILD ARG ARTIFACTORY_USER
 ONBUILD ARG ARTIFACTORY_NPM_SECRET

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,5 @@
-FROM containers.schibsted.io/finntech/node:NODE_VERSION_TEMPLATE
+# syntax = edrevo/dockerfile-plus
+INCLUDE+ ../Dockerfile.base
 
 # Reset NODE_ENV=production
 ENV NODE_ENV test

--- a/Dockerfile.test-onbuild
+++ b/Dockerfile.test-onbuild
@@ -1,4 +1,14 @@
-FROM containers.schibsted.io/finntech/node:test-NODE_VERSION_TEMPLATE
+# syntax = edrevo/dockerfile-plus
+INCLUDE+ ../Dockerfile.base
+
+# Reset NODE_ENV=production
+ENV NODE_ENV test
+
+# Install dependencies for native builds and yarn
+RUN apk add --no-cache make gcc g++ python git || \
+    apk add --no-cache make gcc g++ python3 git # 'python' isn't available in alpine3.12+ \
+
+CMD ["npm", "test"]
 
 # All but package.json is optional
 ONBUILD COPY package.json yarn.lock* .yarnrc* .npmrc* npm-shrinkwrap.json* package-lock.json* ./

--- a/README.md
+++ b/README.md
@@ -196,16 +196,19 @@ Username is your email address. Password is the __API key__ found on [your Artif
 
 Run `release.sh` to build and/or release new versions. The version should match the official Node version.
 
-To just build the image locally for Node `6.9.1` without pushing anything:
-
+To test building the image for both arm64 (Apple M1) & amd64 (Intel) for Node `16.13.0` without pushing anything:
 ```sh-session
-./release.sh build 6.9.1
+./release.sh build 16.13.0
 ```
 
-To build and release that image:
-
+To build and image locally for your local architecture, and add it to your local docker cache for testing:
 ```sh-session
-./release.sh push 6.9.1
+./release.sh buildlocal 16.13.0
+```
+
+To build and release image for both arm64 (Apple M1) & amd64 (Intel):
+```sh-session
+./release.sh push 16.13.0
 ```
 
 🎉 You're done! 🎉

--- a/release.sh
+++ b/release.sh
@@ -6,11 +6,6 @@ err_report() {
 }
 trap 'err_report' ERR
 
-if [[ $(uname -p) == "arm64" ]]; then
-  echo "Building on arm is not supported right now, see https://github.com/finn-no/node-docker/issues/26"
-  exit 1
-fi
-
 if [[ ${1:-} != "build" && ${1:-} != "push" || $# -ne 2 ]]; then
   echo "Usage: $0 [build|push] nodeVersion"
   echo "  e.g. $0 push 12.12.0"

--- a/release.sh
+++ b/release.sh
@@ -189,12 +189,12 @@ printf "\n\nBuilding test-onbuild\n\n"
   docker $BUILD_ARGS -t "$test_onbuild_tag_major" -t "$test_onbuild_tag_minor" -t "$test_onbuild_tag_patch" .
 )
 
-if [[ $COMMAND == "build" ]]; then
-  printf "\nThis is just a build, so new images are NOT pushed and tagged\n\n"
-else
+if [[ $COMMAND == "push" ]]; then
   echo Tagging the commit, and pushing it to GitHub
   git tag "$VERSION" -m \""$VERSION"\"
   git push origin master --follow-tags
+else
+  printf "\nThis is just a build, so new images are NOT pushed and tagged\n\n"
 fi
 
 docker buildx rm "$BUILDX_NODE"

--- a/release.sh
+++ b/release.sh
@@ -24,7 +24,7 @@ if ! echo "" | ${xargs_command} >/dev/null 2>&1; then
   xargs_command="xargs"
 fi
 
-if [[ $COMMAND = "push" && -n $(git status -s) ]]; then
+if [[ $COMMAND == "push" && -n $(git status -s) ]]; then
   echo git working directory is not clean
   exit 1
 fi
@@ -83,7 +83,7 @@ $test_onbuild_tag_patch
 read -p "Do you want to continue? (yN)" -n 1 -r
 echo # move to a new line
 
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+if [[ $REPLY != "y" ]]; then
   exit 1
 fi
 


### PR DESCRIPTION
Add support for building images for both arm64 (Apple M1) and amd64 (Intel).

This changes the flow logic somehow, since we can't do build and push separately after switching to the `docker buildx` command.

The `build` command now builds both architectures, but doesn't store those images in the local docker cache.  There is a new `buildlocal` command for that now.  The reason is that the local docker cache cannot contain images from foreign architectures.

For the same reason multi-stage builds doesn't work well.  I've replaced this by including `Dockerfile.base` in the other Dockerfiles using the [INCLUDE+](https://github.com/edrevo/dockerfile-plus) directive.
